### PR TITLE
Add work type column

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-<!-- # Contributing to Top IT Companies in Bangladesh
+# Contributing to Top IT Companies in Bangladesh
 
 Thank you for contributing to this repository! Please follow these guidelines to ensure smooth collaboration.
 
@@ -6,4 +6,4 @@ Thank you for contributing to this repository! Please follow these guidelines to
 1. Open the `README.md` file and locate the "Company Career Pages" table.
 2. Add or update a row using the format:
    ```markdown
-   | Company Name | [Career](Career Page URL) | Work Type | -->
+   | Company Name | [Career](Career Page URL) | Work Type |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+<!-- # Contributing to Top IT Companies in Bangladesh
+
+Thank you for contributing to this repository! Please follow these guidelines to ensure smooth collaboration.
+
+## Adding or Updating Companies
+1. Open the `README.md` file and locate the "Company Career Pages" table.
+2. Add or update a row using the format:
+   ```markdown
+   | Company Name | [Career](Career Page URL) | Work Type | -->

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Welcome! This repository curates official career pages of 50+ renowned IT compan
 ## ⭐ How to Use
 - Browse the list below to find companies and their official career pages.
 - Click the company name to visit their career portal and view current openings.
+- Check the `Work Type` column to see if the company offers `Onsite`, `Remote`, or `Hybrid` work arrangements.
 
 - If you find this helpful, please give a **star** to support the project!
 
@@ -14,74 +15,80 @@ Welcome! This repository curates official career pages of 50+ renowned IT compan
 
 ## 📋 Company Career Pages
 
-| Company                | Career Page Link                                                                 |
-|------------------------|----------------------------------------------------------------------------------|
-| Brain Station 23       | [Career](https://brainstation-23.easy.jobs/)                                     |
-| Cefalo                 | [Career](https://career.cefalo.com/)                                             |
-| Selise                 | [Career](https://selisegroup.com/about-us/#jobs-main-container)                  |
-| Therap                 | [Career](https://therap.hire.trakstar.com/)                                      |
-| Enosis                 | [Career](https://enosisbd.pinpointhq.com/)                                       |
-| Datasoft               | [Career](https://datasoft-bd.com/career/)                                        |
-| Kaz Software           | [Career](https://kaz.com.bd/ourwork2/category/job_post)                          |
-| DivineIT               | [Career](https://www.divineit.net/about/careers/)                                |
-| BJIT                   | [Career](https://bjitgroup.com/career)                                           |
-| Next Ventures          | [Career](https://career.nextventures.io/)                                        |
-| BracIT                 | [Career](https://www.bracits.com/career)                                         |
-| Ollyo                  | [Career](https://ollyo.com/careers/)                                             |
-| Workspace Infotech     | [Career](https://www.workspaceit.com/career/)                                    |
-| iBos                   | [Career](https://ibos.io/career/)                                                |
-| RiseUp Labs            | [Career](https://riseuplabs.com/jobs/)                                           |
-| Magnito Digital        | [Career](https://magnitodigital.com/career/)                                     |
-| Grameenphone IT        | [Career](https://www.grameenphone.com/about/career/vacant-positions)             |
-| Joomshaper             | [Career](https://www.joomshaper.com/about)                                       |
-| Bkash                  | [Career](https://www.bkash.com/career)                                           |
-| AsthaIT                | [Career](https://www.asthait.com/career/)                                        |
-| Tekarsh                | [Career](https://tekarsh.com/career/)                                            |
-| Startise               | [Career](https://startise.com/careers/)                                          |
-| SSL Wireless           | [Career](https://sslwireless.com/job-openings/)                                  |
-| Nexdecade              | [Career](https://www.nexdecade.com/life-at-a-glance/career)                      |
-| SEBPO                  | [Career](https://sebpo.com/careers/)                                             |
-| Genex Infosys          | [Career](https://genexinfosys.com/career.php)                                    |
-| Truck Lagbe            | [Career](https://trucklagbe.com/career)                                          |
-| Daraz                  | [Career](https://www.daraz.com.bd/careers/)                                      |
-| Musemind               | [Career](https://musemind.agency/career#current-opening)                         |
-| Kolpolok               | [Career](https://kolpolok.com/career/)                                           |
-| Tech Cloud Ltd         | [Career](https://techcloudltd.com/career-at-tech-cloud-ltd/)                     |
-| Relisource             | [Career](https://www.relisource.com/careers/)                                    |
-| Reve Systems           | [Career](https://www.revesoft.com/career)                                        |
-| Apsis Solutions        | [Career](https://apsissolutions.com/career/)                                     |
-| Appnap                 | [Career](https://appnap.io/career)                                               |
-| XpeedStudio            | [Career](https://inside.xpeedstudio.com/)                                        |
-| Strativ AB             | [Career](https://erp360.strativ.se/career)                                       |
-| Pridesys IT            | [Career](https://pridesys.com/careers/)                                          |
-| MediaSoft              | [Career](https://career.mediasoftbd.com/#active-jobs)                            |
-| Sysnova                | [Career](https://www.sysnova.com/index.php/career)                               |
-| BDcalling              | [Career](https://bdcalling.com/career/)                                          |
-| 6Sense                 | [Career](https://6sense.com/about-us/careers/join-us/)                           |
-| Softeko                | [Career](https://www.softeko.co/careers/#current-openings)                       |
-| iFarmer                | [Career](https://ifarmer.asia/career#career_opportunity)                         |
-| Design Monks           | [Career](https://www.designmonks.co/career)                                      |
-| Synesis IT             | [Career](https://synesisit.com.bd/career/)                                       |
-| Priyo                  | [Career](https://www.priyo.com/jobs/)                                            |
-| Durbar Technologies    | [Career](https://www.durbartech.com/career/index.php)                            |
-| All Gen Tech           | [Career](https://allgentech.bamboohr.com/careers)                                |
-| TechnoNext             | [Career](https://technonext.com/career)                                          |
-| Samsung R&D            | [Career](https://research.samsung.com/careers)                                   |
-| Monstar Lab            | [Career](https://monstar-lab.com/bd/about/careers/)                              |
-| Orbitax                | [Career](https://www.linkedin.com/company/orbitax/jobs/)                         |
-| Optimizely             | [Career](https://careers.optimizely.com/search/)                                 |
-| Vivasoft               | [Career](https://vivasoftltd.com/career/#open-position)                          |
-| Craftsmen              | [Career](https://careers.craftsmensoftware.com/jobs)                             |
-| Welldev                | [Career](https://www.welldev.io/careers)                                         |
-| Pathao                 | [Career](https://career.pathao.com/#position)                                    |
-| Chaldal                | [Career](https://chaldal.com/t/Career)                                           |
-| ShareTrip              | [Career](https://www.linkedin.com/company/sharetrip/jobs/)                       |
-| ShopUp                 | [Career](https://www.shopup.org/career)                                          |
-| Jatri                  | [Career](https://jatri.co/career#job-opening)                                    |
-| TigerIT                | [Career](https://www.linkedin.com/company/tigerit-bangladesh-limited/posts/)     |
-| Dynamic Solution       | [Career](https://app.hrythmic.com/recruit/openings/company/dsinnovators/)        |
-| KUIPERZ                | [Career](https://kuiperz.io/careers/)                                            |
-| Tenbyte                | [Career](https://tenbyte.com.my/jobs/)                                           |
+| Company                | Career Page Link                                                                 | Work Type         |
+|------------------------|----------------------------------------------------------------------------------|-------------------|
+| Brain Station 23       | [Career](https://brainstation-23.easy.jobs/)                                     | Onsite            |
+| Cefalo                 | [Career](https://career.cefalo.com/)                                             | Onsite            |
+| Selise                 | [Career](https://selisegroup.com/about-us/#jobs-main-container)                  | Onsite            |
+| Therap                 | [Career](https://therap.hire.trakstar.com/)                                      | Onsite            |
+| Enosis                 | [Career](https://enosisbd.pinpointhq.com/)                                       | Hybrid            |
+| Datasoft               | [Career](https://datasoft-bd.com/career/)                                        | Not Specified     |
+| Kaz Software           | [Career](https://kaz.com.bd/ourwork2/category/job_post)                          | Not Specified     |
+| DivineIT               | [Career](https://www.divineit.net/about/careers/)                                | Not Specified     |
+| BJIT                   | [Career](https://bjitgroup.com/career)                                           | Not Specified     |
+| Next Ventures          | [Career](https://career.nextventures.io/)                                        | Onsite            |
+| BracIT                 | [Career](https://www.bracits.com/career)                                         | Onsite            |
+| Ollyo                  | [Career](https://ollyo.com/careers/)                                             | Onsite            |
+| Workspace Infotech     | [Career](https://www.workspaceit.com/career/)                                    | Not Specified     |
+| iBos                   | [Career](https://ibos.io/career/)                                                | Onsite            |
+| RiseUp Labs            | [Career](https://riseuplabs.com/jobs/)                                           | Onsite            |
+| Magnito Digital        | [Career](https://magnitodigital.com/career/)                                     | Not Specified     |
+| Grameenphone IT        | [Career](https://www.grameenphone.com/about/career/vacant-positions)             | Not Specified     |
+| Joomshaper             | [Career](https://www.joomshaper.com/about)                                       | Onsite            |
+| Bkash                  | [Career](https://www.bkash.com/career)                                           | Onsite            |
+| AsthaIT                | [Career](https://www.asthait.com/career/)                                        | Onsite            |
+| Tekarsh                | [Career](https://tekarsh.com/career/)                                            | Not Specified     |
+| Startise               | [Career](https://startise.com/careers/)                                          | Not Specified     |
+| SSL Wireless           | [Career](https://sslwireless.com/job-openings/)                                  | Not Specified     |
+| Nexdecade              | [Career](https://www.nexdecade.com/life-at-a-glance/career)                      | Not Specified     |
+| SEBPO                  | [Career](https://sebpo.com/careers/)                                             | Not Specified     |
+| Genex Infosys          | [Career](https://genexinfosys.com/career.php)                                    | Not Specified     |
+| Truck Lagbe            | [Career](https://trucklagbe.com/career)                                          | Not Specified     |
+| Daraz                  | [Career](https://www.daraz.com.bd/careers/)                                      | Onsite            |
+| Musemind               | [Career](https://musemind.agency/career#current-opening)                         | Onsite            |
+| Kolpolok               | [Career](https://kolpolok.com/career/)                                           | Onsite            |
+| Tech Cloud Ltd         | [Career](https://techcloudltd.com/career-at-tech-cloud-ltd/)                     | Not Specified     |
+| Relisource             | [Career](https://www.relisource.com/careers/)                                    | Not Specified     |
+| Reve Systems           | [Career](https://www.revesoft.com/career)                                        | Not Specified     |
+| Apsis Solutions        | [Career](https://apsissolutions.com/career/)                                     | Onsite            |
+| Appnap                 | [Career](https://appnap.io/career)                                               | Not Specified     |
+| XpeedStudio            | [Career](https://inside.xpeedstudio.com/)                                        | Not Specified     |
+| Strativ AB             | [Career](https://erp360.strativ.se/career)                                       | Not Specified     |
+| Pridesys IT            | [Career](https://pridesys.com/careers/)                                          | Not Specified     |
+| MediaSoft              | [Career](https://career.mediasoftbd.com/#active-jobs)                            | Not Specified     |
+| Sysnova                | [Career](https://www.sysnova.com/index.php/career)                               | Not Specified     |
+| BDcalling              | [Career](https://bdcalling.com/career/)                                          | Onsite            |
+| 6Sense                 | [Career](https://6sense.com/about-us/careers/join-us/)                           | Onsite            |
+| Softeko                | [Career](https://www.softeko.co/careers/#current-openings)                       | Not Specified     |
+| iFarmer                | [Career](https://ifarmer.asia/career#career_opportunity)                         | Not Specified     |
+| Design Monks           | [Career](https://www.designmonks.co/career)                                      | Not Specified     |
+| Synesis IT             | [Career](https://synesisit.com.bd/career/)                                       | Not Specified     |
+| Priyo                  | [Career](https://www.priyo.com/jobs/)                                            | Onsite            |
+| Durbar Technologies    | [Career](https://www.durbartech.com/career/index.php)                            | Not Specified     |
+| All Gen Tech           | [Career](https://allgentech.bamboohr.com/careers)                                | Not Specified     |
+| TechnoNext             | [Career](https://technonext.com/career)                                          | Onsite            |
+| Samsung R&D            | [Career](https://research.samsung.com/careers)                                   | Onsite            |
+| Monstar Lab            | [Career](https://monstar-lab.com/bd/about/careers/)                              | Not Specified     |
+| Orbitax                | [Career](https://www.linkedin.com/company/orbitax/jobs/)                         | ot Specified      |
+| Optimizely             | [Career](https://careers.optimizely.com/search/)                                 | Onsite            |
+| Vivasoft               | [Career](https://vivasoftltd.com/career/#open-position)                          | Onsite            |
+| Craftsmen              | [Career](https://careers.craftsmensoftware.com/jobs)                             | Not Specified     |
+| Welldev                | [Career](https://www.welldev.io/careers)                                         | Not Specified     |
+| Pathao                 | [Career](https://career.pathao.com/#position)                                    | Onsite            |
+| Chaldal                | [Career](https://chaldal.com/t/Career)                                           | Onsite            |
+| ShareTrip              | [Career](https://www.linkedin.com/company/sharetrip/jobs/)                       | Onsite            |
+| ShopUp                 | [Career](https://www.shopup.org/career)                                          | Onsite            |
+| Jatri                  | [Career](https://jatri.co/career#job-opening)                                    | Onsite            |
+| TigerIT                | [Career](https://www.linkedin.com/company/tigerit-bangladesh-limited/posts/)     | Not Specified     |
+| Dynamic Solution       | [Career](https://app.hrythmic.com/recruit/openings/company/dsinnovators/)        | Not Specified     |
+| KUIPERZ                | [Career](https://kuiperz.io/careers/)                                            | Not Specified     |
+| Tenbyte                | [Career](https://tenbyte.com.my/jobs/)                                           | Not Specified     |
+
+### Work Type Definitions
+- **Onsite**: Work is primarily performed at the company’s office.
+- **Remote**: Work can be done fully from a location of the employee’s choice.
+- **Hybrid**: Work involves a combination of onsite and remote work.
+- **Not Specified**: Work type is unclear or not explicitly stated.
 
 ---
 


### PR DESCRIPTION
### Changes
- Added a `Work Type` column to the company table in `README.md` to indicate `Onsite`, `Remote`, `Hybrid`, or `Not Specified`.
- Added work type definitions in `README.md`.
- Created `CONTRIBUTING.md` with guidelines for adding/updating work type data.
- Populated work types for Brain Station 23, Cefalo, and Selise; others marked as `Not Specified`.

### Notes
- Sources for work types: [e.g., Brain Station 23 job postings, Cefalo career page].
- Community contributions are welcome to update `Not Specified` work types.